### PR TITLE
Fixed

### DIFF
--- a/src/Utils/Extensions/ArrayObject/ArrayObject.php
+++ b/src/Utils/Extensions/ArrayObject/ArrayObject.php
@@ -4,6 +4,7 @@ namespace Clean\Common\Utils\Extensions\ArrayObject;
 
 class ArrayObject implements ArrayObjectInterface, \Iterator, \JsonSerializable, \Countable
 {
+    /** @var ArrayObjectItemInterface[] $items */
     protected $items = [];
 
     protected $unique;

--- a/src/Utils/Extensions/ArrayObject/ArrayObject.php
+++ b/src/Utils/Extensions/ArrayObject/ArrayObject.php
@@ -4,7 +4,7 @@ namespace Clean\Common\Utils\Extensions\ArrayObject;
 
 class ArrayObject implements ArrayObjectInterface, \Iterator, \JsonSerializable, \Countable
 {
-    protected $items;
+    protected $items = [];
 
     protected $unique;
 


### PR DESCRIPTION
- union-megaplan :white_check_mark:
- service-walmart-orders :white_check_mark:
- service-marketplaces :white_check_mark:
- service-ebay-inventory-laminas :white_check_mark:
- service-ebay-orders :white_check_mark:

What may go wrong:
I'm removing the `$items is null` exception. If someone's design relies on expecting ArrayObject->items to be null then we are in trouble